### PR TITLE
Adding `gulpplugin` keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "keywords": [
     "gulp",
+    "gulpplugin",
     "sourceUrl",
     "source",
     "url",


### PR DESCRIPTION
Adding keyword so module now shows up in http://gulpjs.com/plugins/ directory.
